### PR TITLE
Fix TPKeyboardAvoiding_contentInsetForKeyboard

### DIFF
--- a/TPKeyboardAvoiding/UIScrollView+TPKeyboardAvoidingAdditions.m
+++ b/TPKeyboardAvoiding/UIScrollView+TPKeyboardAvoidingAdditions.m
@@ -341,7 +341,13 @@ static const int kStateKey;
     TPKeyboardAvoidingState *state = self.keyboardAvoidingState;
     UIEdgeInsets newInset = self.contentInset;
     CGRect keyboardRect = state.keyboardRect;
-    newInset.bottom = keyboardRect.size.height - MAX((CGRectGetMaxY(keyboardRect) - CGRectGetMaxY(self.bounds)), 0);
+    
+    if (keyboardRect.size.height == 0) {
+        newInset.bottom = state.priorInset.bottom;
+    } else {
+        newInset.bottom = keyboardRect.size.height - MAX((CGRectGetMaxY(keyboardRect) - CGRectGetMaxY(self.bounds)), 0);
+    }
+
     return newInset;
 }
 


### PR DESCRIPTION
Reset newInset.bottom to state.priorInset.bottom if they keyboard is getting closed.